### PR TITLE
add build-essential

### DIFF
--- a/nodejs.Dockerfile
+++ b/nodejs.Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends tini curl libcurl4 nodejs npm libusb-1.0.0 \
+    && apt-get install -y --no-install-recommends build-essential tini curl libcurl4 nodejs npm libusb-1.0.0 \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g yarn \
     && yarn global add typescript ts-node \


### PR DESCRIPTION
This seems to be required for yarn to build the dependencies on ARM (but not on x86) :shrug:
